### PR TITLE
chore: update php 8.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ composer.lock
 vendor
 index.php
 build
+.phpunit.result.cache
+.devcontainer

--- a/composer.json
+++ b/composer.json
@@ -7,14 +7,13 @@
 		"inboud"
 	],
 	"require": {
-		"php": "~5.6|~7.0",
+		"php": "^7.3|^8.0",
 		"guzzlehttp/guzzle": "~6.0"
 	},
 	"require-dev": {
-        "codeclimate/php-test-reporter": "~0.3",
-        "mockery/mockery": "~0.9",
-        "phpunit/phpunit": "~5.0",
-        "squizlabs/php_codesniffer": "~2.3",
+        "mockery/mockery": "^1.4",
+        "phpunit/phpunit": "^9.5.10",
+        "squizlabs/php_codesniffer": "3.6",
         "larapack/dd": "^1.1"
 	},
 	"autoload-dev": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -14,16 +14,17 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
+    <coverage>
+         <include>
+            <directory suffix=".php">src</directory>
+        </include>
+        <report>
+            <html outputDirectory="build/coverage"/>
+            <text outputFile="build/coverage.txt" showUncoveredFiles="false" showOnlySummary="true"/>
+            <clover outputFile="build/logs/clover.xml"/>
+        </report>
+    </coverage>
     <logging>
-        <log type="tap" target="build/report.tap"/>
-        <log type="junit" target="build/report.junit.xml"/>
-        <log type="coverage-html" target="build/coverage" charset="UTF-8" yui="true" highlight="true"/>
-        <log type="coverage-text" target="build/coverage.txt"/>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
+        <junit outputFile="build/report.junit.xml"/>
     </logging>
 </phpunit>

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -3,8 +3,6 @@
 namespace bubbstore\RDStation;
 
 use Mockery;
-use GuzzleHttp\ClientInterface;
-use bubbstore\RDStation\Services\Lead;
 use bubbstore\RDStation\Contracts\LeadInterface;
 
 class ClientTest extends TestCase
@@ -14,7 +12,7 @@ class ClientTest extends TestCase
      */
     protected $rd;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Services/LeadTest.php
+++ b/tests/Services/LeadTest.php
@@ -14,7 +14,7 @@ class LeadTest extends TestCase
      */
     protected $rd;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,12 +6,12 @@ use Mockery;
 use GuzzleHttp\Client;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
-use PHPUnit_Framework_TestCase;
 use GuzzleHttp\Handler\MockHandler;
+use PHPUnit\Framework\TestCase as FrameworkTestCase;
 
-abstract class TestCase extends PHPUnit_Framework_TestCase
+abstract class TestCase extends FrameworkTestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         Mockery::close();
     }


### PR DESCRIPTION
## Descrição

Atualização composer.json para rodar ^8.0 do php e atualização das dependencias. 
Atualização dos testes para rodar com nova versão instalado do phpunit

## Motivação e contexto

Para rodar em versões atualizada do php

## Como isso foi testado?

Em ambientes com php 8.0 e 8.1 foram rodados os testes do projeto